### PR TITLE
feat: improve email address handling

### DIFF
--- a/Sources/Tests/Tuvi.Core.DataStorage.Impl.Tests/DataStorageAccountsTests.cs
+++ b/Sources/Tests/Tuvi.Core.DataStorage.Impl.Tests/DataStorageAccountsTests.cs
@@ -136,7 +136,7 @@ namespace Tuvi.Core.DataStorage.Tests
                 await db.UpdateAccountAsync(account).ConfigureAwait(true);
 
                 var accounts = await db.GetAccountsAsync().ConfigureAwait(true);
-                var updatedAccount = accounts.First(x => x.EmailAddress == account.Email.Address);
+                var updatedAccount = accounts.First(x => x.Email.Address == account.Email.Address);
 
                 Assert.That(newName, Is.EqualTo(updatedAccount.Email.Name), "Account was not updated properly.");
 
@@ -161,7 +161,7 @@ namespace Tuvi.Core.DataStorage.Tests
                 await db.UpdateAccountAuthAsync(account).ConfigureAwait(true);
 
                 var accounts = await db.GetAccountsAsync().ConfigureAwait(true);
-                var updatedAccount = accounts.First(x => x.EmailAddress == account.Email.Address);
+                var updatedAccount = accounts.First(x => x.Email.Address == account.Email.Address);
 
                 Assert.That(newAuth, Is.EqualTo(updatedAccount.AuthData), "Account AuthData wasn't updated properly.");
 
@@ -207,7 +207,7 @@ namespace Tuvi.Core.DataStorage.Tests
                 await db.UpdateAccountFolderStructureAsync(account).ConfigureAwait(true);
 
                 var accounts = await db.GetAccountsAsync().ConfigureAwait(true);
-                var updatedAccount = accounts.First(x => x.EmailAddress == account.Email.Address);
+                var updatedAccount = accounts.First(x => x.Email.Address == account.Email.Address);
 
                 Assert.That(newFolders, Is.EqualTo(updatedAccount.FoldersStructure), "Account folders weren't updated properly.");
                 Assert.That(newFolders[0], Is.EqualTo(updatedAccount.DefaultInboxFolder), "Account default folder wasn't updated properly.");

--- a/Sources/Tests/Tuvi.Core.DataStorage.Impl.Tests/DataStorageAccountsTests.cs
+++ b/Sources/Tests/Tuvi.Core.DataStorage.Impl.Tests/DataStorageAccountsTests.cs
@@ -136,7 +136,7 @@ namespace Tuvi.Core.DataStorage.Tests
                 await db.UpdateAccountAsync(account).ConfigureAwait(true);
 
                 var accounts = await db.GetAccountsAsync().ConfigureAwait(true);
-                var updatedAccount = accounts.First(x => x.Email == account.Email);
+                var updatedAccount = accounts.First(x => x.EmailAddress == account.Email.Address);
 
                 Assert.That(newName, Is.EqualTo(updatedAccount.Email.Name), "Account was not updated properly.");
 
@@ -161,7 +161,7 @@ namespace Tuvi.Core.DataStorage.Tests
                 await db.UpdateAccountAuthAsync(account).ConfigureAwait(true);
 
                 var accounts = await db.GetAccountsAsync().ConfigureAwait(true);
-                var updatedAccount = accounts.First(x => x.Email == account.Email);
+                var updatedAccount = accounts.First(x => x.EmailAddress == account.Email.Address);
 
                 Assert.That(newAuth, Is.EqualTo(updatedAccount.AuthData), "Account AuthData wasn't updated properly.");
 
@@ -207,7 +207,7 @@ namespace Tuvi.Core.DataStorage.Tests
                 await db.UpdateAccountFolderStructureAsync(account).ConfigureAwait(true);
 
                 var accounts = await db.GetAccountsAsync().ConfigureAwait(true);
-                var updatedAccount = accounts.First(x => x.Email.Address == account.Email.Address);
+                var updatedAccount = accounts.First(x => x.EmailAddress == account.Email.Address);
 
                 Assert.That(newFolders, Is.EqualTo(updatedAccount.FoldersStructure), "Account folders weren't updated properly.");
                 Assert.That(newFolders[0], Is.EqualTo(updatedAccount.DefaultInboxFolder), "Account default folder wasn't updated properly.");

--- a/Sources/Tests/Tuvi.Core.DataStorage.Impl.Tests/DataStorageContactsTests.cs
+++ b/Sources/Tests/Tuvi.Core.DataStorage.Impl.Tests/DataStorageContactsTests.cs
@@ -183,7 +183,8 @@ namespace Tuvi.Core.DataStorage.Tests
             Assert.That(contact.LastMessageData, Is.Null);
             Assert.That(contact.LastMessageDataId == 0, Is.True);
 
-            contact.LastMessageData = new LastMessageData(TestData.Account.Email, TestData.Message.Id, System.DateTimeOffset.Now);
+            await db.AddAccountAsync(TestData.Account).ConfigureAwait(true);
+            contact.LastMessageData = new LastMessageData(1, TestData.Account.Email, TestData.Message.Id, System.DateTimeOffset.Now);
 
             await db.UpdateContactAsync(contact, default).ConfigureAwait(true);
 
@@ -201,25 +202,6 @@ namespace Tuvi.Core.DataStorage.Tests
 
             Assert.That(await db.TryAddContactAsync(TestData.Contact, default).ConfigureAwait(true), Is.True);
             Assert.That(await db.TryAddContactAsync(TestData.Contact, default).ConfigureAwait(true), Is.False);
-        }
-
-        [Test]
-        public async Task GetContactsWithLastMessageIdAsync()
-        {
-            using var db = await OpenDataStorageAsync().ConfigureAwait(true);
-            await db.AddAccountAsync(TestData.AccountWithFolder, default).ConfigureAwait(true);
-            var accountEmail = TestData.AccountWithFolder.Email;
-            var message = TestData.GetNewMessage();
-            await db.AddMessageAsync(accountEmail, message).ConfigureAwait(true);
-
-            var message2 = TestData.GetNewMessage();
-            await db.AddMessageAsync(accountEmail, message2).ConfigureAwait(true);
-
-            var contacts = await db.GetContactsWithLastMessageIdAsync(accountEmail, message.Id, default).ConfigureAwait(true);
-            Assert.That(contacts.Any(), Is.False);
-
-            var contacts2 = await db.GetContactsWithLastMessageIdAsync(accountEmail, message2.Id, default).ConfigureAwait(true);
-            Assert.That(contacts2.Count() == 1, Is.True);
         }
 
         [Test]

--- a/Sources/Tests/Tuvi.Core.Tests/TuviMailMessagesTests.cs
+++ b/Sources/Tests/Tuvi.Core.Tests/TuviMailMessagesTests.cs
@@ -1,16 +1,14 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Moq;
-using NUnit.Framework;
 using Tuvi.Core.DataStorage;
 using Tuvi.Core.DataStorage.Impl;
 using Tuvi.Core.Entities;
-using Tuvi.Core.Impl;
 
 namespace Tuvi.Core.Tests
 {
@@ -21,11 +19,6 @@ namespace Tuvi.Core.Tests
         Account _account2;
         readonly EmailAddress _contactAddress1 = new("contact1@test.mail");
         readonly EmailAddress _contactAddress2 = new("contact2@test.mail", "Contact2");
-        readonly EmailAddress _from = new EmailAddress("from@mail.box");
-        readonly EmailAddress _replyTo = new EmailAddress("replyto@mail.box");
-        readonly EmailAddress _to = new EmailAddress("to@mail.box");
-        readonly EmailAddress _cc = new EmailAddress("cc@mail.box");
-        readonly EmailAddress _bcc = new EmailAddress("bcc@mail.box");
 
         public static Message CreateNewMessage(EmailAddress from, EmailAddress to, string folder, uint id)
         {
@@ -290,89 +283,6 @@ namespace Tuvi.Core.Tests
                 }
             }
             await _storage.DeleteMessagesAsync(_account1.Email, "INBOX", messages.Select(x => x.Id).ToList()).ConfigureAwait(true);
-        }
-
-        [Test]
-        [Ignore("Current behavior is different, need to clarify the requirements")]
-        public void CollectContactsFromUnknownAccountShouldBeEmpty()
-        {
-            var messages = GetMessageForContactCollecting();
-
-            var contacts = AccountService.CollectContactsFromMessages(new EmailAddress("unknown@mail.box"), messages).OrderBy(x => x.Email).ToList();
-
-            Assert.That(contacts.Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void CollectContactsAccountIsFrom()
-        {
-            var messages = GetMessageForContactCollecting();
-
-            var contacts = AccountService.CollectContactsFromMessages(_from, messages).OrderBy(x => x.Email).ToList();
-
-            Assert.That(contacts.Count, Is.EqualTo(3));
-            Assert.That(contacts[0].Email, Is.EqualTo(_bcc));
-            Assert.That(contacts[1].Email, Is.EqualTo(_cc));
-            Assert.That(contacts[2].Email, Is.EqualTo(_to));
-        }
-
-        private List<Message> GetMessageForContactCollecting()
-        {
-            var message = CreateNewMessage(_from, _to, "INBOX", 1);
-            message.ReplyTo.Add(_replyTo);
-            message.Cc.Add(_cc);
-            message.Bcc.Add(_bcc);
-            var messages = new List<Message>() { message };
-            return messages;
-        }
-
-        [Test]
-        public void CollectContactsAccountIsReplyTo()
-        {
-            var messages = GetMessageForContactCollecting();
-
-            var contacts = AccountService.CollectContactsFromMessages(_replyTo, messages).OrderBy(x => x.Email).ToList();
-
-            Assert.That(contacts.Count, Is.EqualTo(3));
-            Assert.That(contacts[0].Email, Is.EqualTo(_bcc));
-            Assert.That(contacts[1].Email, Is.EqualTo(_cc));
-            Assert.That(contacts[2].Email, Is.EqualTo(_to));
-        }
-
-        [Test]
-        public void CollectContactsAccountIsTo()
-        {
-            var messages = GetMessageForContactCollecting();
-
-            var contacts = AccountService.CollectContactsFromMessages(_to, messages).OrderBy(x => x.Email).ToList();
-
-            Assert.That(contacts.Count, Is.EqualTo(2));
-            Assert.That(contacts[0].Email, Is.EqualTo(_from));
-            Assert.That(contacts[1].Email, Is.EqualTo(_replyTo));
-        }
-
-        [Test]
-        public void CollectContactsAccountIsCc()
-        {
-            var messages = GetMessageForContactCollecting();
-
-            var contacts = AccountService.CollectContactsFromMessages(_cc, messages).OrderBy(x => x.Email).ToList();
-
-            Assert.That(contacts.Count, Is.EqualTo(2));
-            Assert.That(contacts[0].Email, Is.EqualTo(_from));
-            Assert.That(contacts[1].Email, Is.EqualTo(_replyTo));
-        }
-
-        [Test]
-        public void CollectContactsAccountIsBcc()
-        {
-            var messages = GetMessageForContactCollecting();
-
-            var contacts = AccountService.CollectContactsFromMessages(_bcc, messages).OrderBy(x => x.Email).ToList();
-
-            Assert.That(contacts.Count, Is.EqualTo(2));
-            Assert.That(contacts[0].Email, Is.EqualTo(_from));
-            Assert.That(contacts[1].Email, Is.EqualTo(_replyTo));
         }
     }
 }

--- a/Sources/Tuvi.Core.DataStorage.Impl/DataStorage.cs
+++ b/Sources/Tuvi.Core.DataStorage.Impl/DataStorage.cs
@@ -1512,7 +1512,14 @@ ORDER BY Date DESC, FolderId ASC, Message.Id DESC";
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var account = connection.Find<Account>(contact.LastMessageData.AccountId);
-                contact.LastMessageData.AccountEmail = account?.Email;
+                if (account is null)
+                {
+                    contact.LastMessageData = null; // Account has been deleted, so we remove LastMessageData
+                }
+                else
+                {
+                    contact.LastMessageData.AccountEmail = account.Email;
+                }
             }
             cancellationToken.ThrowIfCancellationRequested();
             contact.Email = GetEmailAddressData(connection, contact.EmailId).ToEmailAddress();

--- a/Sources/Tuvi.Core.DataStorage.Impl/DataStorage.cs
+++ b/Sources/Tuvi.Core.DataStorage.Impl/DataStorage.cs
@@ -1512,7 +1512,7 @@ ORDER BY Date DESC, FolderId ASC, Message.Id DESC";
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var account = connection.Find<Account>(contact.LastMessageData.AccountId);
-                contact.LastMessageData.AccountEmail = account.Email;
+                contact.LastMessageData.AccountEmail = account?.Email;
             }
             cancellationToken.ThrowIfCancellationRequested();
             contact.Email = GetEmailAddressData(connection, contact.EmailId).ToEmailAddress();

--- a/Sources/Tuvi.Core.DataStorage/IDataStorage.cs
+++ b/Sources/Tuvi.Core.DataStorage/IDataStorage.cs
@@ -314,15 +314,6 @@ namespace Tuvi.Core.DataStorage
         Task RemoveContactAvatarAsync(EmailAddress contactEmail, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Gets all contacts whose last message id is <paramref name="messageId"/> and this message is from account with email <paramref name="accountEmail"/>
-        /// </summary>
-        /// <param name="accountEmail"></param>
-        /// <param name="messageId"></param>
-        /// <param name="cancellationToken"></param>
-        /// <exception cref="DataBaseException"/>
-        Task<IEnumerable<Contact>> GetContactsWithLastMessageIdAsync(EmailAddress accountEmail, uint messageId, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Tries to find the last message that refers to contact <paramref name="contactEmail"/> in folder <paramref name="folder"/> of the account with email <paramref name="email"/>. If no message is found, returns null
         /// </summary>
         /// <param name="email"></param>

--- a/Sources/Tuvi.Core.Entities/Account.cs
+++ b/Sources/Tuvi.Core.Entities/Account.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Tuvi.Core.Entities
@@ -57,6 +58,7 @@ namespace Tuvi.Core.Entities
         {
             get
             {
+#pragma warning disable CS0618 // Only for SQLite and internal using
                 if (_Email is null && EmailAddress != null)
                 {
                     _Email = new EmailAddress(EmailAddress, EmailName);
@@ -68,13 +70,18 @@ namespace Tuvi.Core.Entities
                 EmailAddress = value?.Address;
                 EmailName = value?.Name;
                 _Email = null;
+#pragma warning restore CS0618 // Only for SQLite and internal using
             }
         }
         private EmailAddress _Email;
+
+        [Obsolete("only for SQLite and internal using")]
         public string EmailAddress { get; set; }
+        [Obsolete("only for SQLite internal using")]
         public string EmailName { get; set; }
 
         // TODO: remove this property after migration (18.05.2025)
+        [Obsolete("use property Email")]
         public int EmailId { get; set; }
 
         public int GroupId { get; set; }

--- a/Sources/Tuvi.Core.Entities/Account.cs
+++ b/Sources/Tuvi.Core.Entities/Account.cs
@@ -67,7 +67,7 @@ namespace Tuvi.Core.Entities
             {
                 EmailAddress = value?.Address;
                 EmailName = value?.Name;
-                _Email = value;
+                _Email = null;
             }
         }
         private EmailAddress _Email;

--- a/Sources/Tuvi.Core.Entities/Account.cs
+++ b/Sources/Tuvi.Core.Entities/Account.cs
@@ -53,8 +53,28 @@ namespace Tuvi.Core.Entities
         public int Id { get; set; }
 
         [SQLite.Ignore]
-        public EmailAddress Email { get; set; }
-        [SQLite.Indexed]
+        public EmailAddress Email
+        {
+            get
+            {
+                if (_Email is null && EmailAddress != null)
+                {
+                    _Email = new EmailAddress(EmailAddress, EmailName);
+                }
+                return _Email;
+            }
+            set
+            {
+                EmailAddress = value?.Address;
+                EmailName = value?.Name;
+                _Email = value;
+            }
+        }
+        private EmailAddress _Email;
+        public string EmailAddress { get; set; }
+        public string EmailName { get; set; }
+
+        // TODO: remove this property after migration (18.05.2025)
         public int EmailId { get; set; }
 
         public int GroupId { get; set; }

--- a/Sources/Tuvi.Core.Entities/LastMessageData.cs
+++ b/Sources/Tuvi.Core.Entities/LastMessageData.cs
@@ -10,6 +10,10 @@ namespace Tuvi.Core.Entities
 
         [SQLite.Ignore]
         public EmailAddress AccountEmail { get; set; }
+        public int AccountId { get; set; }
+
+        // TODO: remove this property after migration (18.05.2025)
+        [Obsolete("use property AccountId")]
         public int AccountEmailId { get; set; }
 
         public uint MessageId { get; set; }
@@ -17,11 +21,11 @@ namespace Tuvi.Core.Entities
 
         public LastMessageData()
         {
-
         }
 
-        public LastMessageData(EmailAddress accountEmail, uint messageId, DateTimeOffset date)
+        public LastMessageData(int accountId, EmailAddress accountEmail, uint messageId, DateTimeOffset date)
         {
+            AccountId = accountId;
             AccountEmail = accountEmail;
             MessageId = messageId;
             Date = date;

--- a/Sources/Tuvi.Core.Entities/LocalAIAgent.cs
+++ b/Sources/Tuvi.Core.Entities/LocalAIAgent.cs
@@ -31,10 +31,13 @@
         /// Gets or sets the email address associated with the local AI agent.
         /// </summary>
         [SQLite.Indexed]
-        public int EmailId { get; set; }
+        public int AccountId { get; set; }
 
         [SQLite.Ignore]
-        public EmailAddress Email { get; set; }
+        public Account Account { get; set; }
+
+        [SQLite.Ignore]
+        public EmailAddress Email => Account?.Email;
 
         /// <summary>
         /// Gets or sets a value indicating whether the local AI agent is allowed to send emails.

--- a/Sources/Tuvi.Core.Impl/AccountService.cs
+++ b/Sources/Tuvi.Core.Impl/AccountService.cs
@@ -477,31 +477,6 @@ namespace Tuvi.Core.Impl
             }
         }
 
-        public static IEnumerable<Contact> CollectContactsFromMessages(EmailAddress accountEmail, IEnumerable<Message> messages)
-        {
-            foreach (var message in messages.OrderByDescending(message => message.Date))
-            {
-                var contacts = GetMessageContacts(accountEmail, message);
-                foreach (var contact in contacts)
-                {
-                    yield return contact;
-                }
-            }
-        }
-
-        private static IEnumerable<Contact> GetMessageContacts(EmailAddress accountEmail, Message message)
-        {
-            var addresses = message.GetContactEmails(accountEmail);
-
-            var contacts = addresses.GroupBy(email => EmailAddressHelper.GetKeyFromEmail(email))
-                                    .Select(group => group.FirstOrDefault(email => !string.IsNullOrEmpty(email.Name)) ?? group.First())
-                                    .Select(email => new Contact(email.Name, email)
-                                    {
-                                        LastMessageData = new LastMessageData(accountEmail, message.Id, message.Date)
-                                    });
-            return contacts;
-        }
-
         public async Task<int> GetUnreadMessagesCountAsync(CancellationToken cancellationToken)
         {
             int unreadCount = 0;

--- a/Sources/Tuvi.Core.Mail.Impl/Commands.cs
+++ b/Sources/Tuvi.Core.Mail.Impl/Commands.cs
@@ -144,8 +144,8 @@ namespace Tuvi.Core.Mail.Impl
                 await serviceSemaphore.WaitAsync(IsHighPriority, cancellationToken).ConfigureAwait(true);
                 try
                 {
-                    await PrepareToUse(credentialsProvider, cancellationToken).ConfigureAwait(true);
-                    var res = await Execute(cancellationToken).ConfigureAwait(true);
+                    await PrepareAsync(credentialsProvider, cancellationToken).ConfigureAwait(true);
+                    var res = await ExecuteAsync(cancellationToken).ConfigureAwait(true);
                     if (!String.IsNullOrEmpty(requestUniqueeID))
                     {
                         // delete first, don't move to to finally
@@ -187,7 +187,7 @@ namespace Tuvi.Core.Mail.Impl
             }
         }
 
-        private async Task PrepareToUse(ICredentialsProvider credentialsProvider, CancellationToken cancellationToken)
+        private async Task PrepareAsync(ICredentialsProvider credentialsProvider, CancellationToken cancellationToken)
         {
             if (!Service.IsConnected)
             {
@@ -200,7 +200,7 @@ namespace Tuvi.Core.Mail.Impl
             }
         }
 
-        protected abstract Task<T> Execute(CancellationToken cancellationToken);
+        protected abstract Task<T> ExecuteAsync(CancellationToken cancellationToken);
     }
 
     internal class SendCommand : Command<string>
@@ -215,7 +215,7 @@ namespace Tuvi.Core.Mail.Impl
             Message = msg;
         }
 
-        protected override async Task<string> Execute(CancellationToken cancellationToken)
+        protected override async Task<string> ExecuteAsync(CancellationToken cancellationToken)
         {
             Message.Date = DateTime.Now;
             var result = await Sender.SendMessageAsync(Message, cancellationToken).ConfigureAwait(false);
@@ -253,7 +253,7 @@ namespace Tuvi.Core.Mail.Impl
             MessageID = messageID;
         }
 
-        protected override async Task<bool> Execute(CancellationToken cancellationToken)
+        protected override async Task<bool> ExecuteAsync(CancellationToken cancellationToken)
         {
             await Receiver.AppendSentMessageAsync(Message, MessageID, cancellationToken).ConfigureAwait(false);
             return true;
@@ -272,7 +272,7 @@ namespace Tuvi.Core.Mail.Impl
         {
         }
 
-        protected override async Task<IList<Folder>> Execute(CancellationToken cancellationToken)
+        protected override async Task<IList<Folder>> ExecuteAsync(CancellationToken cancellationToken)
         {
             return await Receiver.GetFoldersStructureAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -285,7 +285,7 @@ namespace Tuvi.Core.Mail.Impl
         {
         }
 
-        protected async override Task<Folder> Execute(CancellationToken cancellationToken)
+        protected async override Task<Folder> ExecuteAsync(CancellationToken cancellationToken)
         {
             return await Task.Run(Receiver.GetDefaultInboxFolder, cancellationToken).ConfigureAwait(false);
         }
@@ -300,7 +300,7 @@ namespace Tuvi.Core.Mail.Impl
             Count = count;
         }
 
-        protected override Task<IReadOnlyList<Message>> Execute(CancellationToken cancellationToken)
+        protected override Task<IReadOnlyList<Message>> ExecuteAsync(CancellationToken cancellationToken)
         {
             return Receiver.GetMessagesAsync(FolderPath, Count, cancellationToken);
         }
@@ -321,7 +321,7 @@ namespace Tuvi.Core.Mail.Impl
             ID = id;
         }
 
-        protected override Task<Message> Execute(CancellationToken cancellationToken)
+        protected override Task<Message> ExecuteAsync(CancellationToken cancellationToken)
         {
             return Receiver.GetMessageAsync(FolderPath, ID, cancellationToken);
         }
@@ -354,7 +354,7 @@ namespace Tuvi.Core.Mail.Impl
             Count = count;
         }
 
-        protected override Task<IReadOnlyList<Message>> Execute(CancellationToken cancellationToken)
+        protected override Task<IReadOnlyList<Message>> ExecuteAsync(CancellationToken cancellationToken)
         {
             return Receiver.GetLaterMessagesAsync(FolderPath, Count, LastMessage, cancellationToken);
         }
@@ -379,7 +379,7 @@ namespace Tuvi.Core.Mail.Impl
             Fast = fast;
         }
 
-        protected override Task<IReadOnlyList<Message>> Execute(CancellationToken cancellationToken)
+        protected override Task<IReadOnlyList<Message>> ExecuteAsync(CancellationToken cancellationToken)
         {
             return Receiver.GetEarlierMessagesAsync(FolderPath, Count, LastMessage, Fast, cancellationToken);
         }
@@ -410,7 +410,7 @@ namespace Tuvi.Core.Mail.Impl
             UIDs = uids;
         }
 
-        protected async override Task<bool> Execute(CancellationToken cancellationToken)
+        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
         {
             await Receiver.MarkMessagesAsReadAsync(UIDs, FolderPath, cancellationToken).ConfigureAwait(false);
             return true;
@@ -432,7 +432,7 @@ namespace Tuvi.Core.Mail.Impl
             UIDs = uids;
         }
 
-        protected async override Task<bool> Execute(CancellationToken cancellationToken)
+        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
         {
             await Receiver.MarkMessagesAsUnReadAsync(UIDs, FolderPath, cancellationToken).ConfigureAwait(false);
             return true;
@@ -456,7 +456,7 @@ namespace Tuvi.Core.Mail.Impl
             PermanentDelete = permanentDelete;
         }
 
-        protected async override Task<bool> Execute(CancellationToken cancellationToken)
+        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
         {
             await Receiver.DeleteMessagesAsync(UIDS, FolderPath, PermanentDelete, cancellationToken).ConfigureAwait(false);
             return true;
@@ -483,7 +483,7 @@ namespace Tuvi.Core.Mail.Impl
             TargetFolder = targetFolder;
         }
 
-        protected async override Task<bool> Execute(CancellationToken cancellationToken)
+        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
         {
             await Receiver.MoveMessagesAsync(UIDS, FolderPath, TargetFolder, cancellationToken).ConfigureAwait(false);
             return true;
@@ -508,7 +508,7 @@ namespace Tuvi.Core.Mail.Impl
             UIDs = uids;
         }
 
-        protected async override Task<bool> Execute(CancellationToken cancellationToken)
+        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
         {
             await Receiver.FlagMessagesAsync(UIDs, FolderPath, cancellationToken).ConfigureAwait(false);
             return true;
@@ -530,7 +530,7 @@ namespace Tuvi.Core.Mail.Impl
             UIDs = uids;
         }
 
-        protected async override Task<bool> Execute(CancellationToken cancellationToken)
+        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
         {
             await Receiver.UnflagMessagesAsync(UIDs, FolderPath, cancellationToken).ConfigureAwait(false);
             return true;
@@ -552,7 +552,7 @@ namespace Tuvi.Core.Mail.Impl
             Message = message;
         }
 
-        protected override Task<Message> Execute(CancellationToken cancellationToken)
+        protected override Task<Message> ExecuteAsync(CancellationToken cancellationToken)
         {
             return Receiver.AppendDraftMessageAsync(Message, cancellationToken);
         }
@@ -580,7 +580,7 @@ namespace Tuvi.Core.Mail.Impl
             UID = uid;
         }
 
-        protected override Task<Message> Execute(CancellationToken cancellationToken)
+        protected override Task<Message> ExecuteAsync(CancellationToken cancellationToken)
         {
             return Receiver.ReplaceDraftMessageAsync(UID, Message, cancellationToken);
         }

--- a/Sources/Tuvi.Core.Mail.Impl/Commands.cs
+++ b/Sources/Tuvi.Core.Mail.Impl/Commands.cs
@@ -144,8 +144,8 @@ namespace Tuvi.Core.Mail.Impl
                 await serviceSemaphore.WaitAsync(IsHighPriority, cancellationToken).ConfigureAwait(true);
                 try
                 {
-                    await PrepareAsync(credentialsProvider, cancellationToken).ConfigureAwait(true);
-                    var res = await ExecuteAsync(cancellationToken).ConfigureAwait(true);
+                    await PrepareToUse(credentialsProvider, cancellationToken).ConfigureAwait(true);
+                    var res = await Execute(cancellationToken).ConfigureAwait(true);
                     if (!String.IsNullOrEmpty(requestUniqueeID))
                     {
                         // delete first, don't move to to finally
@@ -187,7 +187,7 @@ namespace Tuvi.Core.Mail.Impl
             }
         }
 
-        private async Task PrepareAsync(ICredentialsProvider credentialsProvider, CancellationToken cancellationToken)
+        private async Task PrepareToUse(ICredentialsProvider credentialsProvider, CancellationToken cancellationToken)
         {
             if (!Service.IsConnected)
             {
@@ -200,7 +200,7 @@ namespace Tuvi.Core.Mail.Impl
             }
         }
 
-        protected abstract Task<T> ExecuteAsync(CancellationToken cancellationToken);
+        protected abstract Task<T> Execute(CancellationToken cancellationToken);
     }
 
     internal class SendCommand : Command<string>
@@ -215,7 +215,7 @@ namespace Tuvi.Core.Mail.Impl
             Message = msg;
         }
 
-        protected override async Task<string> ExecuteAsync(CancellationToken cancellationToken)
+        protected override async Task<string> Execute(CancellationToken cancellationToken)
         {
             Message.Date = DateTime.Now;
             var result = await Sender.SendMessageAsync(Message, cancellationToken).ConfigureAwait(false);
@@ -253,7 +253,7 @@ namespace Tuvi.Core.Mail.Impl
             MessageID = messageID;
         }
 
-        protected override async Task<bool> ExecuteAsync(CancellationToken cancellationToken)
+        protected override async Task<bool> Execute(CancellationToken cancellationToken)
         {
             await Receiver.AppendSentMessageAsync(Message, MessageID, cancellationToken).ConfigureAwait(false);
             return true;
@@ -272,7 +272,7 @@ namespace Tuvi.Core.Mail.Impl
         {
         }
 
-        protected override async Task<IList<Folder>> ExecuteAsync(CancellationToken cancellationToken)
+        protected override async Task<IList<Folder>> Execute(CancellationToken cancellationToken)
         {
             return await Receiver.GetFoldersStructureAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -285,7 +285,7 @@ namespace Tuvi.Core.Mail.Impl
         {
         }
 
-        protected async override Task<Folder> ExecuteAsync(CancellationToken cancellationToken)
+        protected async override Task<Folder> Execute(CancellationToken cancellationToken)
         {
             return await Task.Run(Receiver.GetDefaultInboxFolder, cancellationToken).ConfigureAwait(false);
         }
@@ -300,7 +300,7 @@ namespace Tuvi.Core.Mail.Impl
             Count = count;
         }
 
-        protected override Task<IReadOnlyList<Message>> ExecuteAsync(CancellationToken cancellationToken)
+        protected override Task<IReadOnlyList<Message>> Execute(CancellationToken cancellationToken)
         {
             return Receiver.GetMessagesAsync(FolderPath, Count, cancellationToken);
         }
@@ -321,7 +321,7 @@ namespace Tuvi.Core.Mail.Impl
             ID = id;
         }
 
-        protected override Task<Message> ExecuteAsync(CancellationToken cancellationToken)
+        protected override Task<Message> Execute(CancellationToken cancellationToken)
         {
             return Receiver.GetMessageAsync(FolderPath, ID, cancellationToken);
         }
@@ -354,7 +354,7 @@ namespace Tuvi.Core.Mail.Impl
             Count = count;
         }
 
-        protected override Task<IReadOnlyList<Message>> ExecuteAsync(CancellationToken cancellationToken)
+        protected override Task<IReadOnlyList<Message>> Execute(CancellationToken cancellationToken)
         {
             return Receiver.GetLaterMessagesAsync(FolderPath, Count, LastMessage, cancellationToken);
         }
@@ -379,7 +379,7 @@ namespace Tuvi.Core.Mail.Impl
             Fast = fast;
         }
 
-        protected override Task<IReadOnlyList<Message>> ExecuteAsync(CancellationToken cancellationToken)
+        protected override Task<IReadOnlyList<Message>> Execute(CancellationToken cancellationToken)
         {
             return Receiver.GetEarlierMessagesAsync(FolderPath, Count, LastMessage, Fast, cancellationToken);
         }
@@ -410,7 +410,7 @@ namespace Tuvi.Core.Mail.Impl
             UIDs = uids;
         }
 
-        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
+        protected async override Task<bool> Execute(CancellationToken cancellationToken)
         {
             await Receiver.MarkMessagesAsReadAsync(UIDs, FolderPath, cancellationToken).ConfigureAwait(false);
             return true;
@@ -432,7 +432,7 @@ namespace Tuvi.Core.Mail.Impl
             UIDs = uids;
         }
 
-        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
+        protected async override Task<bool> Execute(CancellationToken cancellationToken)
         {
             await Receiver.MarkMessagesAsUnReadAsync(UIDs, FolderPath, cancellationToken).ConfigureAwait(false);
             return true;
@@ -456,7 +456,7 @@ namespace Tuvi.Core.Mail.Impl
             PermanentDelete = permanentDelete;
         }
 
-        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
+        protected async override Task<bool> Execute(CancellationToken cancellationToken)
         {
             await Receiver.DeleteMessagesAsync(UIDS, FolderPath, PermanentDelete, cancellationToken).ConfigureAwait(false);
             return true;
@@ -483,7 +483,7 @@ namespace Tuvi.Core.Mail.Impl
             TargetFolder = targetFolder;
         }
 
-        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
+        protected async override Task<bool> Execute(CancellationToken cancellationToken)
         {
             await Receiver.MoveMessagesAsync(UIDS, FolderPath, TargetFolder, cancellationToken).ConfigureAwait(false);
             return true;
@@ -508,7 +508,7 @@ namespace Tuvi.Core.Mail.Impl
             UIDs = uids;
         }
 
-        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
+        protected async override Task<bool> Execute(CancellationToken cancellationToken)
         {
             await Receiver.FlagMessagesAsync(UIDs, FolderPath, cancellationToken).ConfigureAwait(false);
             return true;
@@ -530,7 +530,7 @@ namespace Tuvi.Core.Mail.Impl
             UIDs = uids;
         }
 
-        protected async override Task<bool> ExecuteAsync(CancellationToken cancellationToken)
+        protected async override Task<bool> Execute(CancellationToken cancellationToken)
         {
             await Receiver.UnflagMessagesAsync(UIDs, FolderPath, cancellationToken).ConfigureAwait(false);
             return true;
@@ -552,7 +552,7 @@ namespace Tuvi.Core.Mail.Impl
             Message = message;
         }
 
-        protected override Task<Message> ExecuteAsync(CancellationToken cancellationToken)
+        protected override Task<Message> Execute(CancellationToken cancellationToken)
         {
             return Receiver.AppendDraftMessageAsync(Message, cancellationToken);
         }
@@ -580,7 +580,7 @@ namespace Tuvi.Core.Mail.Impl
             UID = uid;
         }
 
-        protected override Task<Message> ExecuteAsync(CancellationToken cancellationToken)
+        protected override Task<Message> Execute(CancellationToken cancellationToken)
         {
             return Receiver.ReplaceDraftMessageAsync(UID, Message, cancellationToken);
         }


### PR DESCRIPTION
Methods and classes have been updated to use the EmailAddress property instead of EmailId, improving code consistency and simplifying account logic. Methods in DataStorageAccountsTests.cs, DataStorage.cs, Account.cs, and LocalAIAgent.cs have been updated accordingly. Migration code has been added to PasswordProtectedStorage.cs to transfer legacy EmailId data to the new EmailAddress property, preventing data loss.