### PR TITLE
refactor: update API URLs and URL construction

### DIFF
--- a/Sources/Tuvi.Core.Dec.Ethereum/EthereumNetworkConfig.cs
+++ b/Sources/Tuvi.Core.Dec.Ethereum/EthereumNetworkConfig.cs
@@ -81,7 +81,7 @@ namespace Tuvi.Core.Dec.Ethereum
         /// </summary>
         public static readonly EthereumNetworkConfig MainNet = new EthereumNetworkConfig(
             name: "mainnet",
-            explorerApiBaseUrl: new Uri("https://api.etherscan.io/api", UriKind.Absolute),
+            explorerApiBaseUrl: new Uri("https://api.etherscan.io/v2/api?chainid=1", UriKind.Absolute),
             chainId: EthereumNetwork.MainNet,
             humanName: "Ethereum Mainnet");
 
@@ -90,7 +90,7 @@ namespace Tuvi.Core.Dec.Ethereum
         /// </summary>
         public static readonly EthereumNetworkConfig Sepolia = new EthereumNetworkConfig(
             name: "sepolia",
-            explorerApiBaseUrl: new Uri("https://api-sepolia.etherscan.io/api", UriKind.Absolute),
+            explorerApiBaseUrl: new Uri("https://api.etherscan.io/v2/api?chainid=11155111", UriKind.Absolute),
             chainId: EthereumNetwork.Sepolia,
             humanName: "Ethereum Sepolia Testnet");
     }

--- a/Sources/Tuvi.Core.Dec.Ethereum/Explorer/EtherscanExplorerClient.cs
+++ b/Sources/Tuvi.Core.Dec.Ethereum/Explorer/EtherscanExplorerClient.cs
@@ -136,7 +136,7 @@ namespace Tuvi.Core.Dec.Ethereum.Explorer
 
         private async Task<List<TxItem>> FetchPageAsync(string address, int page, int offset, CancellationToken ct)
         {
-            var url = _apiBase + $"?module={AccountModule}&action={ActionTxList}&address={address}&startblock={StartBlock}&endblock={EndBlockDefault}&page={page}&offset={offset}&sort={SortDescending}{AppendKey()}";
+            var url = _apiBase + $"&module={AccountModule}&action={ActionTxList}&address={address}&startblock={StartBlock}&endblock={EndBlockDefault}&page={page}&offset={offset}&sort={SortDescending}{AppendKey()}";
             int delayMs = InitialBackoffMs;
 
             for (int attempt = 1; attempt <= MaxAttempts; attempt++)
@@ -242,7 +242,7 @@ namespace Tuvi.Core.Dec.Ethereum.Explorer
                 return null;
             }
 
-            var proxyUrl = $"{_apiBase}?module={ProxyModule}&action={ActionEthGetTransactionByHash}&txhash={txHash}{AppendKey()}";
+            var proxyUrl = $"{_apiBase}&module={ProxyModule}&action={ActionEthGetTransactionByHash}&txhash={txHash}{AppendKey()}";
             try
             {
                 using (var resp = await _httpClient.GetAsync(proxyUrl, ct).ConfigureAwait(false))


### PR DESCRIPTION
- Update `explorerApiBaseUrl` to use new Etherscan v2 API with `chainid`.
- Adjust URL construction logic to handle `_apiBase` containing query params.
- Improve maintainability by aligning with updated Etherscan API structure.